### PR TITLE
Fix issue with topologyObject not being respected

### DIFF
--- a/src/geojson-canvas.js
+++ b/src/geojson-canvas.js
@@ -102,7 +102,7 @@ AFRAME.registerComponent('geojson-canvas', {
         var isTopojson = json.features === undefined;
         if (isTopojson) {
             var topologyObjectName = data.topologyObject;
-            if (data.topologyObject !== '') {
+            if (!data.topologyObject) {
                 topologyObjectName = Object.keys(json.objects)[0];
             }
             this.features = topojson.feature(json, json.objects[topologyObjectName]).features;

--- a/src/geojson.js
+++ b/src/geojson.js
@@ -99,7 +99,7 @@ AFRAME.registerComponent('geojson', {
         var features;
         if (isTopojson) {
             var topologyObjectName = data.topologyObject;
-            if (data.topologyObject !== '') {
+            if (!data.topologyObject) {
                 topologyObjectName = Object.keys(json.objects)[0];
             }
             features = topojson.feature(json, json.objects[topologyObjectName]).features;


### PR DESCRIPTION
Change logic for setting topologyObjectName so that it uses the value passed in by the topologyObject property.

Fixes #2